### PR TITLE
Bugfix concerning certain docstrings

### DIFF
--- a/gendoc.lisp
+++ b/gendoc.lisp
@@ -182,7 +182,8 @@ and written to this location.
       (let ((ds (documentation sym 'function)))
         (if (and (> (length ds) 0)
                  (string= (subseq ds 0 2) "=>"))
-            (subseq ds (position #\Newline ds))
+            (let ((br (position #\Newline ds)))
+	      (if br (subseq ds br) "")) 
             ds))))
    "*Undocumented!*"))
 


### PR DESCRIPTION
If a docstring was a single line starting with `=>`, it caused `subseq`
in `apiref-doc` to crash, because `(position #\Newline ds)` returned nil.
Now in that case an empty string is returned.
